### PR TITLE
幾つか直しました．

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,14 @@ add_library(seed_solutions_sdk
   )
 target_link_libraries(seed_solutions_sdk ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(seed_solutions_sdk ${catkin_EXPORTED_TARGETS})
+
+install(TARGETS seed_solutions_sdk
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+

--- a/src/aero3_command.cpp
+++ b/src/aero3_command.cpp
@@ -1,4 +1,5 @@
 #include "seed_solutions_sdk/aero3_command.h"
+#include <iostream> // for cout/cerr
 using namespace aero;
 using namespace controller;
 

--- a/src/seed3_command.cpp
+++ b/src/seed3_command.cpp
@@ -1,4 +1,5 @@
 #include "seed_solutions_sdk/seed3_command.h"
+#include <iostream> // for cout/cerr
 using namespace seed;
 using namespace controller;
 


### PR DESCRIPTION
1. 　コンパイル時に以下のエラーがでていたので #include を追加しました．
```
[seed_solutions_sdk:make] /tmp/fuga/src/seed_solutions_sdk/src/aero3_command.cpp: In member function ‘void aero::controller::SerialCommunication::readBuffer(std::vector<unsigned char>&, uint8_t)’:
[seed_solutions_sdk:make] /tmp/fuga/src/seed_solutions_sdk/src/aero3_command.cpp:103:10: error: ‘cerr’ is not a member of ‘std’
[seed_solutions_sdk:make]      std::cerr << "Read Timeout" << std::endl;
[seed_solutions_sdk:make]           ^~~~
[seed_solutions_sdk:make] /tmp/fuga/src/seed_solutions_sdk/src/aero3_command.cpp:103:10: note: suggested alternative: ‘erf’
[seed_solutions_sdk:make]      std::cerr << "Read Timeout" << std::endl;
[seed_solutions_sdk:make]           ^~~~
[seed_solutions_sdk:make]           erf
[seed_solutions_sdk:make] /tmp/fuga/src/seed_solutions_sdk/src/seed3_command.cpp: In member function ‘void seed::controller::SeedCommand::waitForScriptEnd(int)’:
[seed_solutions_sdk:make] /tmp/fuga/src/seed_solutions_sdk/src/seed3_command.cpp:1005:14: error: ‘cout’ is not a member of ‘std’
[seed_solutions_sdk:make]          std::cout << "Script of ID " << id << " is the end." << std::endl;
[seed_solutions_sdk:make]               ^~~~
[seed_solutions_sdk:make] /tmp/fuga/src/seed_solutions_sdk/src/seed3_command.cpp:1005:14: note: suggested alternative: ‘count’
[seed_solutions_sdk:make]          std::cout << "Script of ID " << id << " is the end." << std::endl;
[seed_solutions_sdk:make]               ^~~~
[seed_solutions_sdk:make]               count
[seed_solutions_sdk:make] CMakeFiles/seed_solutions_sdk.dir/build.make:86: recipe for target 'CMakeFiles/seed_solutions_sdk.dir/src/aero3_command.cpp.o' failed
[seed_solutions_sdk:make] make[2]: *** [CMakeFiles/seed_solutions_sdk.dir/src/aero3_command.cpp.o] Error 1

```

2. CMakeLists.txt に install がなかったので追加しました．